### PR TITLE
Unicode sequence normalization

### DIFF
--- a/projects/angular-keyboard/package.json
+++ b/projects/angular-keyboard/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@taskbase/angular-keyboard",
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/projects/angular-keyboard/src/lib/fake-input/fake-input.component.ts
+++ b/projects/angular-keyboard/src/lib/fake-input/fake-input.component.ts
@@ -92,7 +92,7 @@ export class FakeInputComponent implements OnInit, OnDestroy {
       // We want the text to use canonical composition of special symbols like
       // german umlaute and avoid treating the combining diaeresis character
       // separately.
-      .normalize("NFC")
+      .normalize("NFKC")
       .split('')
       .map(char => {
         return {

--- a/projects/angular-keyboard/src/lib/fake-input/fake-input.component.ts
+++ b/projects/angular-keyboard/src/lib/fake-input/fake-input.component.ts
@@ -95,7 +95,6 @@ export class FakeInputComponent implements OnInit, OnDestroy {
       .normalize("NFC")
       .split('')
       .map(char => {
-        console.log(char)
         return {
           char
         };

--- a/projects/angular-keyboard/src/lib/fake-input/fake-input.component.ts
+++ b/projects/angular-keyboard/src/lib/fake-input/fake-input.component.ts
@@ -89,7 +89,13 @@ export class FakeInputComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.registerInputField();
     this.chars = this.initialText
-      .split('').map(char => {
+      // We want the text to use canonical composition of special symbols like
+      // german umlaute and avoid treating the combining diaeresis character
+      // separately.
+      .normalize("NFC")
+      .split('')
+      .map(char => {
+        console.log(char)
         return {
           char
         };


### PR DESCRIPTION
It turns out that the so called [COMBINING DIAERESIS' (U+0308)](https://www.fileformat.info/info/unicode/char/0308/index.htm) is the culprit here. We now normalize the character sequence before we loop over it. This way we ensure not ending up treating the diaeresis as a separate character during looping. 

--- 

Check https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#description for more details on the normalization.


